### PR TITLE
Remove bogus options from benchmark build

### DIFF
--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -48,7 +48,6 @@ function (swift_benchmark_compile_archopts)
       "-target" "${target}"
       "-F" "${sdk}/../../../Developer/Library/Frameworks"
       "-${BENCH_COMPILE_ARCHOPTS_OPT}"
-      "-D" "INTERNAL_CHECKS_ENABLED"
       "-no-link-objc-runtime"
       "-I" "${srcdir}/utils/ObjectiveCTests")
 
@@ -63,7 +62,6 @@ function (swift_benchmark_compile_archopts)
       "-target" "${target}"
       "-F" "${sdk}/../../../Developer/Library/Frameworks"
       "-${driver_opt}"
-      "-D" "INTERNAL_CHECKS_ENABLED"
       "-no-link-objc-runtime")
 
   set(bench_library_objects)


### PR DESCRIPTION
This option is misleading, and never should have been there in the first place.  Fortunately it was having no effect because the standard library is already compiled to SIL and the internal checks have been eliminated from any benchmark build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
